### PR TITLE
Installation note for mac users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,59 @@ BeautifyTex and enter. All done!
   cd "~/Library/Application Support/Sublime Text 2/Packages/"
   git clone git://github.com/ketan/BeautifyLatex.git
 ```
+
+### Note for Mac users
+If you are using OS X El Capitan and get the following error 
+
+    Error: can't specify None for path argument
+
+while saving `tex` files, you may want to check the following things.
+
+1. Do you have `latexindent`? This can be checked by typing `which latexindent` in the terminal. If you have `latexindent` installed, you shall get the following message telling you the directory, in which your `latexindent` resides.
+
+        $ which latexindent
+        /Library/TeX/texbin/latexindent
+
+  If you do not have `latexindent` at all, you may consider upgrading your [`MacTeX`](http://tug.org/mactex/) or install `latexindent` manually. See CTAN page of `latexindent` [here](https://www.ctan.org/pkg/latexindent?lang=en).
+
+2. Is your `latexindent` functional? To check this, go to the terminal, `cd` to the directory containing your `latexindent`, and type `perl latexindent`. If your `latexindent` is functional, you shall see its version information (see below).
+
+        $ cd /Library/TeX/texbin/
+        $ perl latexindent
+        latexindent.pl version 2.1R
+        usage: latexindent.pl [options] [file][.tex]
+              -h  help (see the documentation for detailed instructions and examples)
+              -o  output to another file; sample usage
+                        latexindent.pl -o myfile.tex outputfile.tex
+              -w  overwrite the current file- a backup will be made, but still be careful
+              -s  silent mode- no output will be given to the terminal
+              -t  tracing mode- verbose information given to the log file
+              -l  use localSettings.yaml (assuming it exists in the directory of your file)
+              -d  ONLY use defaultSettings.yaml, ignore ALL user files
+              -c=cruft directory used to specify the location of backup files and indent.log
+
+  Otherwise, you will see certain error message saying that `YAML::Tiny` (or some other components) was missing. To install these components, type the following lines in terminal (you may need to input your admin password).
+
+
+        $ sudo cpan App::cpanminus
+        $ sudo cpanm YAML::Tiny
+        $ sudo perl -MCPAN -e 'install "File::HomeDir"'
+
+
+  After executing the above lines, check the availability of `latexindent` by typing `perl latexindent` again in the terminal.
+
+3. Install [`Fix Mac Path`](https://packagecontrol.io/packages/Fix%20Mac%20Path) package and add the following line
+
+        {
+          "additional_path_items": ["/Library/TeX/texbin"]
+        }
+
+  in the `user` settings of `BeautifyLatex`. The string `"/Library/TeX/texbin"` is the directory containing your `latexindent`. Change it accordingly if you have a different directory.
+
+4. If the problem has been solved, great! Otherwise (I mean you still saw `Error: can't specify None for path argument`), type the following line in terminal,
+        
+        $ sudo ln -s /Library/TeX/texbin/latexindent /Library/TeX/texbin/latexindent.pl
+    
+  which links `latexindent.pl` to `latexindent`. (It seems that by default `MacTeX` does not ship with `latexindent.pl`.) After linking, `BeautifyLatex` should run beautifully now.
+
+As a reference, you may want to read this [thread](http://tex.stackexchange.com/questions/326600/use-latexindent-pl-with-beautifylatex-in-sublime-text/326619?noredirect=1#comment799934_326619) on tex.stackexchange.com.


### PR DESCRIPTION
The additional note is to guide the installation for mac users, fixing the `path` and `latexindent` vs `latexindent.pl` problem.
