### PR TITLE
Expand default latexindent executable names, allow user to specify latexindent path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ Prettifies latex code using [latexindent.pl](https://github.com/cmhughes/latexin
 This package offers a pre-save hook, i.e., your latex files will be reformatted automatically before saving. To activate this feature, set:
 
 ```
-  "run_on_save": true,
+"run_on_save": true,
 ```
 
 
 The sublime command "beautify_latex" performs a save after formatting. You can disable this default by setting:
 
 ```
-  "save_on_beautify": false
+"save_on_beautify": false
 ```
 
 You can change the file patterns handled by this plugin in the settings:
 
 ```
-    "file_patterns": [ "\\.tex"],
+"file_patterns": [ "\\.tex"],
 ```
 
 ### Tabs or Spaces
@@ -34,7 +34,7 @@ By default, Sublime does not translate tabs to spaces. If you wish to use tabs y
 ### Key Binding
 
 ```
-  ctrl + cmd + k on OS X, or ctrl + alt + k on Windows
+ctrl + cmd + L on OS X, or ctrl + alt + L on Windows
 ```
 
 # Installation
@@ -48,14 +48,13 @@ In ST2, press "cmd + shift + p" and then type "install".
 Once you see "Package Control: Install Package", enter.
 
 When the packages load, another selection window will appear. Type
-
-BeautifyTex and enter. All done!
+BeautifyLatex and enter. All done!
 
 ### Manual Installation
 
 ```bash
-  cd "~/Library/Application Support/Sublime Text 2/Packages/"
-  git clone git://github.com/ketan/BeautifyLatex.git
+cd "~/Library/Application Support/Sublime Text 2/Packages/"
+git clone git://github.com/ketan/BeautifyLatex.git
 ```
 
 ### Note for Mac users

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ cd "~/Library/Application Support/Sublime Text 2/Packages/"
 git clone git://github.com/ketan/BeautifyLatex.git
 ```
 
+### Manually setting the path to `latexindent`
+
+If you have `latexindent` in a non-standard location, you can set the path to the `latexindent` executable by specifying `latexindent_path` in your BeautifyLatex settings. For example:
+
+```
+"latexindent_path": "/Library/TeX/texbin/latexindent"
+```
+
 ### Note for Mac users
 If you are using OS X El Capitan and get the following error 
 
@@ -97,18 +105,14 @@ while saving `tex` files, you may want to check the following things.
 
   After executing the above lines, check the availability of `latexindent` by typing `perl latexindent` again in the terminal.
 
-3. Install [`Fix Mac Path`](https://packagecontrol.io/packages/Fix%20Mac%20Path) package and add the following line
+3. Install [`Fix Mac Path`](https://packagecontrol.io/packages/Fix%20Mac%20Path) package. This will allow BeautifyLatex to find your `latexindent` executable if it is in your `PATH`. 
 
-        {
-          "additional_path_items": ["/Library/TeX/texbin"]
-        }
+4. If BeautifyLatex still doesn't work, you may need to manually set the path of `latexindent` executable by adding the following to your BeautifyLatex settings:
+ 
 
-  in the `user` settings of `BeautifyLatex`. The string `"/Library/TeX/texbin"` is the directory containing your `latexindent`. Change it accordingly if you have a different directory.
+         "latexindent_path": "/Library/TeX/texbin/latexindent"     
 
-4. If the problem has been solved, great! Otherwise (I mean you still saw `Error: can't specify None for path argument`), type the following line in terminal,
-        
-        $ sudo ln -s /Library/TeX/texbin/latexindent /Library/TeX/texbin/latexindent.pl
-    
-  which links `latexindent.pl` to `latexindent`. (It seems that by default `MacTeX` does not ship with `latexindent.pl`.) After linking, `BeautifyLatex` should run beautifully now.
+ 
+  `/Library/TeX/texbin/latexindent` is the default location in MacTeX 2016. If you are using another TeX distribution, you may need to change this accordingly.
 
 As a reference, you may want to read this [thread](http://tex.stackexchange.com/questions/326600/use-latexindent-pl-with-beautifylatex-in-sublime-text/326619?noredirect=1#comment799934_326619) on tex.stackexchange.com.

--- a/beautify_latex.py
+++ b/beautify_latex.py
@@ -52,9 +52,12 @@ class BeautifyLatexCommand(sublime_plugin.TextCommand):
       raise Exception(msg)
 
   def cmd(self, path = "-"):
-    executable = (self.which('latexindent.exe') or 
-                  self.which('latexindent.pl') or
-                  self.which('latexindent'))
+    if self.settings.get('latexindent_path'):
+      executable = self.settings.get('latexindent_path') 
+    else:
+      executable = (self.which('latexindent.exe') or
+                    self.which('latexindent.pl') or
+                    self.which('latexindent'))
     if not os.path.exists(executable):
       msg = "executable: '" + executable + "' not found."
       raise Exception(msg)

--- a/beautify_latex.py
+++ b/beautify_latex.py
@@ -52,7 +52,9 @@ class BeautifyLatexCommand(sublime_plugin.TextCommand):
       raise Exception(msg)
 
   def cmd(self, path = "-"):
-    executable = self.which('latexindent.exe') or self.which('latexindent.pl')
+    executable = (self.which('latexindent.exe') or 
+                  self.which('latexindent.pl') or
+                  self.which('latexindent'))
     if not os.path.exists(executable):
       msg = "executable: '" + executable + "' not found."
       raise Exception(msg)


### PR DESCRIPTION
This PR does two things:
1. It adds `latexindent` to the list of default executable names. This is for MacTeX, which links `latexindent.pl` to `/Library/TeX/texbin/latexindent`. (I think MacTeX also adds `/Library/TeX/texbin` to `PATH` at installation, but I'm not 100% sure.)
2. It allows the user to specify `latexindent_path` in their BeautifyLatex settings, for non-standard locations or stubborn environments.

I edited the README to reflect these changes.
