### PR TITLE
Update README.md to have correct keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ By default, Sublime does not translate tabs to spaces. If you wish to use tabs y
 ### Key Binding
 
 ```
-  ctrl + cmd + k on OS X, or ctrl + alt + k on Windows
+  ctrl + cmd + l on OS X, or ctrl + alt + l on Windows
 ```
 
 # Installation


### PR DESCRIPTION
Default keybindings are 
`ctrl + cmd + l` on OS X: https://github.com/ketan/BeautifyLatex/blob/e8923c6c12151464437f6b42cb4c7cbc8b854047/Default%20(OSX).sublime-keymap#L2
and `ctrl + alt + l` on Windows: https://github.com/ketan/BeautifyLatex/blob/e8923c6c12151464437f6b42cb4c7cbc8b854047/Default%20(Windows).sublime-keymap#L2

updated readme to match <3